### PR TITLE
Cookbook - Added immediate starts to the Blu service

### DIFF
--- a/Cookbooks/blu/metadata.rb
+++ b/Cookbooks/blu/metadata.rb
@@ -4,4 +4,4 @@ maintainer_email 'YOUR_EMAIL'
 license          'All rights reserved'
 description      'Installs/Configures blu'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.1'
+version          '0.1.2'

--- a/Cookbooks/blu/recipes/service.rb
+++ b/Cookbooks/blu/recipes/service.rb
@@ -28,7 +28,7 @@ end
 cookbook_file node['blu']['root'] + '\_BluService.exe' do
     source 'BluService.exe'
     action :create
-    notifies :run, 'powershell_script[register_blu_service]'
+    notifies :run, 'powershell_script[register_blu_service]', :immediately
 end
 
 # If bluservice.exe file is updated by cookbook: stop service > copy file > start service
@@ -81,7 +81,7 @@ powershell_script 'register_blu_service' do
     }  
   EOF
   action :nothing
-  notifies :start, 'service[BluService]'
+  notifies :start, 'service[BluService]', :immediately
 end
 
 # Start Blu Service


### PR DESCRIPTION
Added immediate starts to the Blu service in the cookbook so Blu can be immediately used after installation. This way we can do terraform apply and run the whole stack instead of a second chef run.
